### PR TITLE
Update alphagateway_class.php

### DIFF
--- a/alphagateway_class.php
+++ b/alphagateway_class.php
@@ -167,9 +167,9 @@ class WC_Gateway_Alpha extends WC_Payment_Gateway {
                 'country'       => ( WC()->version >= '3.0.0' ) ? $order->get_billing_country() : $order->billing_country
 				);
 		
-		$lang = 'el';
-		if (substr(get_locale(), 0, 2) == 'en') {
-			$lang = 'en';
+		$lang = 'en';
+		if (substr(get_locale(), 0, 2) == 'el') {
+			$lang = 'el';
 		}
 		
 		$args = array(


### PR DESCRIPTION
Lines 170 to 172 websites in languages other than english do refer to the gateway in greek language, for example a hotel customer goes to the page in german and he gets redirected to the bank's gateway in greek instead of in english. With the proposed change it would be the opposite.